### PR TITLE
Bugfix for Content-Type treatment

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,16 @@ public handle(@requestBody body: any) {
 #### Parsing request body as JSON
 By default, the request body will be parsed as JSON if the request `Content-Type` header is not present, or is set to `application/json`.
 
-To control the behaviour of parsing the request body, an optional property `parseJSON` can be passed to the `@requestBody` decorator:
+To control the behaviour of parsing the request body, an optional property `parseJson` can be passed to the `@requestBody` decorator:
 ```typescript
 @handle
-public handle(@requestBody({parseJSON: true}) body: any){
+public handle(@requestBody({ parseJson: true }) body: any){
     return body;
 }
 ```
-The `parseJSON` property can be either `boolean | string | (string | undefined)[]`, supporting the following behaviour:
+The `parseJson` property can be either `boolean | string | (string | undefined)[]`, supporting the following behaviour:
 
-* `boolean`: parse as JSON, if `parseJSON === true`.
+* `boolean`: parse as JSON, if `parseJson === true`.
 * `string`: parse as JSON, if the request `Content-Type` header is equal to the `string`.
 * `(string | undefined)[]`: parse as JSON if the request `Content-Type` header matches any of the items in the array, 
   following the same rules for a `string` as above. Additionally, the array can contain `undefined` items, indicating that the request body should be parsed as well when the request `Content-Type` header is not present.  
@@ -73,7 +73,7 @@ This will parse any request body for which the request `Content-Type` header
 ##### Supported content types
 The `@requestBody` decorator can be augmented with a check on supported content types.
   The property for this is `contentType`. The `contentType` property can be either
-  `string | (string | undefined)[]`, following the same behaviour as the `parseJSON` property.
+  `string | (string | undefined)[]`, following the same behaviour as the `parseJson` property.
 
 For example:
 ```typescript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nederlandsespoorwegen/mijnns-tsl-toolkit",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nederlandsespoorwegen/mijnns-tsl-toolkit",
-      "version": "1.3.0",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "reflect-metadata": "^0.1.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nederlandsespoorwegen/mijnns-tsl-toolkit",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nederlandsespoorwegen/mijnns-tsl-toolkit",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "reflect-metadata": "^0.1.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nederlandsespoorwegen/mijnns-tsl-toolkit",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": false,
   "author": {
     "name": "Team Mijn NS",

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,2 @@
+export * from './unsupported-media-type.error';
+export * from './unreadable-request-body.error';

--- a/src/models/dynamic-metadata.model.ts
+++ b/src/models/dynamic-metadata.model.ts
@@ -11,7 +11,7 @@ export interface RequestBodyProps {
     contentType?: SupportedContentTypes
 }
 
-interface MemberProps {
+export interface MemberProps {
     requestBodyProps?: RequestBodyProps;
     eventIndex?: number;
     contextIndex?: number;

--- a/src/util/content-type.util.ts
+++ b/src/util/content-type.util.ts
@@ -1,0 +1,35 @@
+import { ParseJsonOptions, SupportedContentTypes } from '../models';
+
+/**
+ * Return the media-type directive of the given Content-Type field or null if it's missing
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
+ */
+export function extractMediaType(contentType: string): string | undefined {
+    if (contentType) {
+        const parts = contentType.split(';');
+        if (parts[0]) {
+            return parts[0].trim();
+        } else {
+            return undefined;
+        }
+    } else {
+        return undefined;
+    }
+}
+
+export function contentTypeIsSupported(supported: SupportedContentTypes, target: string | undefined): boolean {
+    return supported.some(value => {
+        if (value == undefined) {
+            return target == undefined;
+        }
+        return value === target;
+    });
+}
+
+export function shouldParseEventBody(parseJson: ParseJsonOptions = ['application/json', undefined], contentType: string | undefined): boolean {
+    if (typeof parseJson === 'boolean') {
+        return parseJson;
+    }
+
+    return contentTypeIsSupported(parseJson as SupportedContentTypes, contentType);
+}

--- a/src/util/content-type.util.ts
+++ b/src/util/content-type.util.ts
@@ -17,7 +17,7 @@ export function extractMediaType(contentType: string): string | undefined {
     }
 }
 
-export function contentTypeIsSupported(supported: SupportedContentTypes, target: string | undefined): boolean {
+export function isSupportedContentType(supported: SupportedContentTypes, target: string | undefined): boolean {
     return supported.some(value => {
         if (value == undefined) {
             return target == undefined;
@@ -26,10 +26,10 @@ export function contentTypeIsSupported(supported: SupportedContentTypes, target:
     });
 }
 
-export function shouldParseEventBody(parseJson: ParseJsonOptions = ['application/json', undefined], contentType: string | undefined): boolean {
+export function shouldJsonParseEventBody(parseJson: ParseJsonOptions = ['application/json', undefined], contentType: string | undefined): boolean {
     if (typeof parseJson === 'boolean') {
         return parseJson;
     }
 
-    return contentTypeIsSupported(parseJson as SupportedContentTypes, contentType);
+    return isSupportedContentType(parseJson as SupportedContentTypes, contentType);
 }

--- a/src/util/parameter-injection.util.ts
+++ b/src/util/parameter-injection.util.ts
@@ -1,0 +1,170 @@
+import { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import { UnreadableRequestBodyError } from '../errors';
+import { UnsupportedMediaTypeError } from '../errors/unsupported-media-type.error';
+import { DynamicMetadata, MemberProps } from '../models';
+import { toLowerCaseKeys } from '../util/case-insensitive-lookup.util';
+import { isSupportedContentType, extractMediaType, shouldJsonParseEventBody } from '../util/content-type.util';
+
+type Headers = { [key: string]: any };
+
+interface Param {
+    index: number;
+    value: any;
+}
+
+/**
+ * Return a list of values that will be injected into the implementation's handler function with a spread operator.
+ * Meaning the returned list shall match the handler's signature length and types as much as possible.
+ *
+ * The given metadata contains "index" properties (@see MemberProps), which tell us what request parameters
+ * the implementing handler wants to have injected, and on which parameter index they want them.
+ *
+ * (ex: [requestBodyIndex: 1] means the request body should be the 2nd element in this return value)
+ * In the above example, if nothing is specified to go on index 0, that element will be null.
+ *
+ * This function first gathers all requested parameters in no particular order, then builds the list with each
+ * parameter on the correct index.
+ */
+export function getParameters(metadata: DynamicMetadata, event: APIGatewayProxyEvent, context: Context) {
+    const handlerProps = metadata.members != null ? metadata.members![metadata.handler!] : null;
+    if (handlerProps != null) {
+        let params = [] as Param[];
+        const lowercaseHeaders = toLowerCaseKeys(event.headers || {});
+
+        if (handlerProps.requestHeaderIndexes != null) {
+            params = params.concat(getRequestHeaderParams(handlerProps, lowercaseHeaders));
+        }
+        if (handlerProps.pathParamIndexes != null) {
+            params = params.concat(getPathParams(handlerProps, event));
+        }
+        if (handlerProps.queryParamIndexes != null) {
+            params = params.concat(getQueryParams(handlerProps, event));
+        }
+        if (handlerProps.requestBodyProps != null) {
+            params = params.concat(getRequestBodyParams(handlerProps, event, lowercaseHeaders));
+        }
+        if (handlerProps.authorizerIndex != null) {
+            params = params.concat(getAuthorizerParams(handlerProps, event));
+        }
+        if (handlerProps.eventIndex != null) {
+            params = params.concat(getEventParams(handlerProps, event));
+        }
+        if (handlerProps.contextIndex != null) {
+            params = params.concat(getContextParams(handlerProps, context));
+        }
+
+        const maxIndex = Math.max(...params.map((p) => p.index));
+        const returnValue = [];
+        for (let i = 0; i <= maxIndex; i++) {
+            const match = params.find((p) => p.index === i);
+            if (match) {
+                returnValue.push(match.value);
+            } else {
+                returnValue.push(null);
+            }
+        }
+
+        return returnValue;
+    } else {
+        return [];
+    }
+}
+
+function getRequestHeaderParams(props: MemberProps, lowercaseHeaders: Headers): Param[] {
+    if (props.requestHeaderIndexes != null) {
+        return Object.keys(props.requestHeaderIndexes!).map((h) => ({
+            index: props.requestHeaderIndexes![h],
+            value: lowercaseHeaders[h.toLowerCase()],
+        }));
+    } else {
+        return [];
+    }
+}
+
+function getPathParams(props: MemberProps, event: APIGatewayProxyEvent): Param[] {
+    if (props.pathParamIndexes != null) {
+        return Object.keys(props.pathParamIndexes!).map((p) => ({
+            index: props.pathParamIndexes![p],
+            value: (event.pathParameters || {})[p],
+        }));
+    } else {
+        return [];
+    }
+}
+
+function getQueryParams(props: MemberProps, event: APIGatewayProxyEvent): Param[] {
+    if (props.queryParamIndexes != null) {
+        return Object.keys(props.queryParamIndexes!).map((p) => ({
+            index: props.queryParamIndexes![p],
+            value: (event.queryStringParameters || {})[p],
+        }));
+    } else {
+        return [];
+    }
+}
+
+function getRequestBodyParams(props: MemberProps, event: APIGatewayProxyEvent, lowercaseHeaders: Headers): Param[] {
+    const requestBodyProps = props.requestBodyProps;
+    if (requestBodyProps != null) {
+        const mediaType = extractMediaType(lowercaseHeaders['content-type']);
+
+        if (requestBodyProps.contentType != null && !isSupportedContentType(requestBodyProps.contentType, mediaType)) {
+            throw new UnsupportedMediaTypeError(requestBodyProps.contentType);
+        }
+
+        const index = requestBodyProps.index;
+        if (event.body != null) {
+            if (shouldJsonParseEventBody(requestBodyProps.parseJson, mediaType)) {
+                return [{ index, value: parseJsonEventBody(event.body) }];
+            } else {
+                return [{ index, value: event.body }];
+            }
+        } else {
+            return [{ index, value: undefined }];
+        }
+    } else {
+        return [];
+    }
+}
+
+function getAuthorizerParams(props: MemberProps, event: APIGatewayProxyEvent): Param[] {
+    if (props.authorizerIndex != null) {
+        if (event.requestContext != null && event.requestContext.authorizer != null) {
+            return [{ index: props.authorizerIndex, value: event.requestContext.authorizer }];
+        } else {
+            return [{ index: props.authorizerIndex, value: undefined }];
+        }
+    } else {
+        return [];
+    }
+}
+
+function getEventParams(props: MemberProps, event: APIGatewayProxyEvent): Param[] {
+    if (props.eventIndex != null) {
+        return [{ index: props.eventIndex, value: event }];
+    } else {
+        return [];
+    }
+}
+
+function getContextParams(props: MemberProps, context: Context): Param[] {
+    if (props.contextIndex != null) {
+        return [{ index: props.contextIndex, value: context }];
+    } else {
+        return [];
+    }
+}
+
+function parseJsonEventBody(body: any): any {
+    if (body == null) {
+        return null;
+    } else if (typeof body === 'string') {
+        try {
+            return JSON.parse(body);
+        } catch (err) {
+            throw new UnreadableRequestBodyError();
+        }
+    } else {
+        return body;
+    }
+}

--- a/test/authorizer.test.ts
+++ b/test/authorizer.test.ts
@@ -13,7 +13,7 @@ beforeAll(() => {
     process.env.LAMBDA_TASK_ROOT = '/';
 });
 
-describe('ns-lambda-kit authorizer test', () => {
+describe('authorizer test', () => {
     it('should properly pass the authorizer when present', async () => {
         const handler = lambdaEntry(TestLambda);
         const event = JSON.parse(`{

--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -34,7 +34,7 @@ beforeAll(() => {
     process.env.LAMBDA_TASK_ROOT = '/';
 });
 
-describe('ns-lambda-kit error test', () => {
+describe('error test', () => {
     it('should properly handle a caught error', async () => {
         const handler = lambdaEntry(TestLambda);
         const event = JSON.parse(`{

--- a/test/event-context.test.ts
+++ b/test/event-context.test.ts
@@ -16,8 +16,8 @@ beforeAll(() => {
     process.env.LAMBDA_TASK_ROOT = '/';
 });
 
-describe('ns-lambda-kit event context test', () => {
-    it('should properly pass path and query params', async () => {
+describe('event context test', () => {
+    it('should properly pass the Lambda event and context', async () => {
         const handler = lambdaEntry(TestLambda);
         const event = JSON.parse(`{
             "hello": "world"

--- a/test/get-case-insensitive-header.test.ts
+++ b/test/get-case-insensitive-header.test.ts
@@ -1,6 +1,6 @@
 import { getCaseInsensitiveHeader } from '../src';
 
-describe('ns-lambda-kit get case insensitive header test', () => {
+describe('get case insensitive header test', () => {
     it('should return the matched header', async () => {
         const event = {
             headers: {

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -39,7 +39,7 @@ beforeAll(() => {
     process.env.LAMBDA_TASK_ROOT = '/';
 });
 
-describe('ns-lambda-kit logger test', () => {
+describe('logger test', () => {
     it('should call the setAwsRequest() method of the custom logger and handle its errors', async () => {
         const handler = lambdaEntry(TestLambda);
         const event = JSON.parse(`{ "hello": "world" }`);

--- a/test/params.test.ts
+++ b/test/params.test.ts
@@ -15,7 +15,7 @@ beforeAll(() => {
     process.env.LAMBDA_TASK_ROOT = '/';
 });
 
-describe('ns-lambda-kit params test', () => {
+describe('params test', () => {
     it('should properly pass path and query params', async () => {
         const handler = lambdaEntry(TestLambda);
         const event = JSON.parse(`{

--- a/test/requestBody.test.ts
+++ b/test/requestBody.test.ts
@@ -79,7 +79,7 @@ beforeAll(() => {
     process.env.LAMBDA_TASK_ROOT = '/';
 });
 
-describe('ns-lambda-kit requestBody test', () => {
+describe('requestBody test', () => {
 
     const reqBody = {
         string: 'Hello there!',

--- a/test/requestBody.test.ts
+++ b/test/requestBody.test.ts
@@ -96,6 +96,7 @@ describe('ns-lambda-kit requestBody test', () => {
         { reqBody, lambda: Default, contentType: 'text/plain',                              expectedBody: { type: 'string', body: JSON.stringify(reqBody) } },
         { reqBody, lambda: Default, contentType: undefined,                                 expectedBody: { type: 'object', body: reqBody } },
         { reqBody, lambda: Default, contentType: 'application/json',                        expectedBody: { type: 'object', body: reqBody } },
+        { reqBody, lambda: Default, contentType: 'application/json; charset=UTF-8',         expectedBody: { type: 'object', body: reqBody } },
         { reqBody, lambda: DontParseJson, contentType: 'application/json',                  expectedBody: { type: 'string', body: JSON.stringify(reqBody) } },
         { reqBody, lambda: DoParseJson, contentType: 'text/plain',                          expectedBody: { type: 'object', body: reqBody } },
         { reqBody, lambda: JsonMatcher, contentType: 'application/json',                    expectedBody: { type: 'object', body: reqBody } },

--- a/test/response-entity.test.ts
+++ b/test/response-entity.test.ts
@@ -21,7 +21,7 @@ beforeAll(() => {
     process.env.LAMBDA_TASK_ROOT = '/';
 });
 
-describe('ns-lambda-kit response entity test', () => {
+describe('response entity test', () => {
     it('should properly do a happy flow', async () => {
         const handler = lambdaEntry(TestLambda);
         const event = JSON.parse(`{}`);

--- a/test/simple.test.ts
+++ b/test/simple.test.ts
@@ -23,7 +23,7 @@ beforeAll(() => {
     process.env.LAMBDA_TASK_ROOT = '/';
 });
 
-describe('ns-lambda-kit simple test', () => {
+describe('simple test', () => {
     it('should properly do a happy flow', async () => {
         const handler = lambdaEntry(TestLambda);
         const event = JSON.parse(`{

--- a/test/static-metadata.test.ts
+++ b/test/static-metadata.test.ts
@@ -15,7 +15,7 @@ beforeAll(() => {
     process.env.LAMBDA_TASK_ROOT = '/';
 });
 
-describe('ns-lambda-kit static metadata test', () => {
+describe('static metadata test', () => {
     it('should properly fetch the metadata', async () => {
         const metadata = StaticMetadata.get(TestLambda);
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type

- For incoming Content-Type headers, extract the media-type directive so supported content types will still match even with a boundary or charset directive
- Move some functions to a separate module
- Export some error classes so they don't have to be imported on their actual path